### PR TITLE
docs(front-end-engineering): 更新接口配置文档并添加开源项目页面

### DIFF
--- a/docs/front-end-engineering/第16章：接口相关配置.md
+++ b/docs/front-end-engineering/第16章：接口相关配置.md
@@ -139,16 +139,16 @@ const instance = axios.create({
 #### 多环境的接口地址配置
 
 在项目开发过程中，通常需要根据不同的环境（如：开发环境、测试环境、生产环境）来配置不同的接口地址。因此，接口地址配置需要支持多环境配置。
-在 Vue 项目中，可以通过`process.env`对象来获取环境变量。因此，我们可以将接口地址配置为环境变量，然后在`config.js`文件中根据环境变量来设置接口请求的基础地址。
+在 Vue 项目中，可以通过`import.meta.env`对象来获取环境变量。因此，我们可以将接口地址配置为环境变量，然后在`config.js`文件中根据环境变量来设置接口请求的基础地址。
 
 ```bash
 # 文件地址：.env.development
-VUE_APP_API_BASE_URL=http://localhost:3000/api
+VITE_APP_API_BASE_URL=http://localhost:3000/api
 ```
 
 ```bash
 # 文件地址：.env.production
-VUE_APP_API_BASE_URL=https://api.example.com
+VITE_APP_API_BASE_URL=https://api.example.com
 ```
 
 ```js
@@ -156,7 +156,7 @@ VUE_APP_API_BASE_URL=https://api.example.com
 import axios from 'axios'
 
 const instance = axios.create({
-  baseURL: process.env.VUE_APP_API_BASE_URL
+  baseURL: import.meta.env.VITE_APP_API_BASE_URL
 })
 ```
 
@@ -276,12 +276,12 @@ export const login = (data) => {
 
 ```bash
 # 文件地址：.env.development
-VUE_APP_API_BASE_URL=http://localhost:3000/api
+VITE_APP_API_BASE_URL=http://localhost:3000/api
 ```
 
 ```bash
 # 文件地址：.env.production
-VUE_APP_API_BASE_URL=https://api.example.com
+VITE_APP_API_BASE_URL=https://api.example.com
 ```
 
 ```js
@@ -303,7 +303,7 @@ import instance from './config'
 
 // 用户登录
 export const login = (data) => {
-  return instance.post(`${process.env.VUE_APP_API_BASE_URL}/user/login`, data)
+  return instance.post(`${import.meta.env.VITE_APP_API_BASE_URL}/user/login`, data)
 }
 ```
 
@@ -370,7 +370,7 @@ export const login = (data) => {
 # 文件地址：.env
 
 # 域名白名单
-VUE_APP_WHITE_LIST=http://localhost:4000/api,http://localhost:5000/api
+VITE_APP_WHITE_LIST=http://localhost:4000/api,http://localhost:5000/api
 ```
 
 ```js
@@ -382,7 +382,7 @@ const instance = axios.create({
 })
 
 // 读取域名白名单
-const whitelist = process.env.VUE_APP_WHITE_LIST.split(',')
+const whitelist = import.meta.env.VITE_APP_WHITE_LIST.split(',')
 
 // 请求拦截器
 instance.interceptors.request.use(
@@ -455,8 +455,8 @@ instance.interceptors.request.use(
 
 ```bash
 # 文件地址：.env
-VUE_APP_APP_KEY=your_app_key
-VUE_APP_APP_SECRET=your_app_secret
+VITE_APP_APP_KEY=your_app_key
+VITE_APP_APP_SECRET=your_app_secret
 ```
 
 ```js
@@ -471,8 +471,8 @@ instance.interceptors.request.use(
     // 添加公共参数
     config.params = {
       ...config.params,
-      appKey: process.env.VUE_APP_APP_KEY,
-      appSecret: process.env.VUE_APP_APP_SECRET,
+      appKey: import.meta.env.VITE_APP_APP_KEY,
+      appSecret: import.meta.env.VITE_APP_APP_SECRET,
     }
 
     return config

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -1,0 +1,17 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: 个人开源项目
+
+features:
+  - title: render-jupyter-notebook-vue
+    details: RenderJupyterNotebook 是一个 vue 3.x 组件，通过 JavaScript 实现 jupyter notebook 文件的还原渲染。渲染效果基本和JupyterLab的保持一致。这是因为最底层的渲染逻辑是直接引用于 JupyterLab 并进行了抽离组装。其中核心代码在src/utils/notebook中的Class Notebook。
+    link: https://github.com/Z-J-wang/render-jupyter-notebook-vue
+    linkText: Learn more
+  - title: molstar-viewer-vue
+    details: molstar-viewer-vue将Molstar Viewer封装为Vue组件，以便于在Vue项目中呈现molstar。
+    link: https://github.com/Z-J-wang/render-jupyter-notebook-vue
+    linkText: Learn more
+---

--- a/docs/special-column.md
+++ b/docs/special-column.md
@@ -6,6 +6,10 @@ hero:
   name: 专栏汇总
 
 features:
+  - title: 前端工程化专栏（完善中）
+    details: 本专栏主要介绍前端工程化相关的内容，包括但不限于模块化、组件化、自动化构建、代码规范、性能优化等。
+    link: /front-end-engineering
+    linkText: Learn more
   - title: 杂谈专栏
     details: 一些闲聊、一些瞎扯、一些突发奇想、一些乱七八糟。
     link: /tittle-tattle
@@ -13,10 +17,6 @@ features:
   - title: 前端与 SEO 专栏
     details: 深入探讨 SEO 的概念、相关知识和在前端项目中的优化方法。
     link: /seo
-    linkText: Learn more
-  - title: 前端工程化专栏（完善中）
-    details: 本专栏主要介绍前端工程化相关的内容，包括但不限于模块化、组件化、自动化构建、代码规范、性能优化等。
-    link: /front-end-engineering
     linkText: Learn more
   - title: Vue 3 迁移策略笔记
     details: 本专栏为读后笔记，所有的篇幅是基于 Vue 官方文档《v3 迁移指南》，然后对相关的知识点做了补充和列举。


### PR DESCRIPTION
- 更新接口配置文档，将 VUE_APP_ 前缀改为 VITE_APP_ 前缀
- 添加开源项目页面，介绍个人开源项目
- 调整专栏汇总页面布局，优化前端工程化专栏展示