### PR TITLE
docs(tittle-tattle): 更新跨域问题浅析文档

### DIFF
--- a/docs/tittle-tattle/跨域问题浅析.md
+++ b/docs/tittle-tattle/跨域问题浅析.md
@@ -51,13 +51,17 @@ CORS 工作机制很简单，浏览器将 CORS 需要的相关信息通过请求
       - 如果服务器确认允许这一类的请求，则响应正常并在响应头中携带`Access-Control-Allow-Origin`、`Access-Control-Allow-Methods`、`Access-Control-Allow-Headers`以及`Access-Control-Max-Age`等字段。浏览器接收到响应后立即发送真实请求。这时发送的真实请求的处理逻辑和简单请求一致。
       - 如果服务器拒绝这类请求，同样会返回一个正常的 HTTP 响应。但是没有任何 CORS 相关的响应头字段。这时，浏览器就会认定服务器不同意这类请求，**拦截响应数据并触发 CORS 错误**。
 
-> **关于浏览器拦截跨域请求的响应内容**：
+> **关于简单请求和复杂请求的区分**
+>
+> 详见：[简单请求 - 跨源资源共享（CORS） - HTTP | MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/CORS#简单请求)
+
+> **关于浏览器拦截跨域请求的响应内容**
 >
 > 当一个请求被浏览器识别为**不允许的跨域请求**时，浏览器会自动拦截请求的响应内容，阻止响应内容加载到渲染进程中。这也就是为什么在 Devtools 的 Network 中查看被阻止的跨域请求时，Response 是一片空白的原因。
 >
 > 其中，针对跨域标签（如：`<script>`，`<img>`）请求的响应内容，浏览器主要采用**CORB**（跨源读取阻止器，Cross-Origin Read Blocking）技术来进行拦截。
 
-> **CORB 概述**：
+> **CORB 概述**
 >
 > CORB 是一种浏览器安全机制，旨在减少跨站脚本（XSS）攻击的风险。当浏览器接收到来自不同源的响应时，CORB 会检查响应的内容类型（Content-Type）和响应体（response body）的“嗅探”（sniffing）结果。如果响应被标记为可执行的脚本类型（如 JavaScript），但其内容看起来更像是 HTML 或其他非脚本类型的数据，CORB 会阻止该响应的加载和执行，以防止潜在的恶意脚本执行。
 >


### PR DESCRIPTION
- 新增简单请求和复杂请求的区分说明
- 更新浏览器拦截跨域请求的响应内容部分
- 优化文档结构，增加小标题和链接